### PR TITLE
Allow both Device and DevDevice to exist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 
 dependencies {
     // See issue #11. This is here when we need it
-    // compile fileTree(dir: 'lib', include: ['*.jar'])
+    compile fileTree(dir: 'lib', include: ['*.jar'])
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'
 }

--- a/src/main/java/DevDevice.java
+++ b/src/main/java/DevDevice.java
@@ -1,19 +1,19 @@
  /**
  * <p>Resource-locking device with circular bit storage.</p>
- * 
+ *
  * <p><b>Version:</b>
  * <p>v1.2.5.1
  * <p><b>Author:</b>
  * <p>Michael Palme
- * 
+ *
  * @author Michael Palme
  * @version 1.2.5.1
- * 
+ *
  **/
 
 import java.lang.Math;
 
-public class Device
+public class DevDevice extends Device
 {
    /** Default number of bits to reveal per peek. */
    public static final int DEFAULT_PEEKS = 2;
@@ -23,16 +23,16 @@ public class Device
    public static final char VALUE_FALSE = 'F';
    /** Character indicator of true. */
    public static final char VALUE_TRUE = 'T';
-   
+
    private boolean[] bitLockArray; // '1' and '0' bit storage
    private int rotateOffset, // So spin() doesn't move contents, just indexes
                numToPeek; // User specified number of bits to look at
    private String toReturn; // peek() and toString() use this storage
-   
+
    /**
     * Construct device using defaults.
     */
-   public Device()
+   public DevDevice()
    {
       this.numToPeek = DEFAULT_PEEKS;
       this.rotateOffset = 0;
@@ -40,25 +40,25 @@ public class Device
       for(int randomizer = 0; randomizer < DEFAULT_SIZE; randomizer++)
          this.bitLockArray[randomizer] = Math.random()<0.5? true : false;
    }//End Constructor #1
-   
+
    /**
     * Construct device with specified bits for testing.
     * @param initialBits the bit values for this test device
     * @param bitsPerPeek the number of bits to disclose via peek or set via poke
     */
-   public Device(boolean[] initialBits, int bitsPerPeek)
+   public DevDevice(boolean[] initialBits, int bitsPerPeek)
    {
       this.numToPeek = bitsPerPeek;
       this.rotateOffset = 0;
       this.bitLockArray = initialBits;
    }//End Constructor #2
-   
+
    /**
     * Construct device with specified size and number of peel/poke bits.
     * @param size the number of bits stored in this device
     * @param bitsPerPeek the number of bits to disclose via peek or set via poke
     */
-   public Device(int size, int bitsPerPeek)
+   public DevDevice(int size, int bitsPerPeek)
    {
       this.numToPeek = bitsPerPeek;
       this.rotateOffset = 0;
@@ -66,44 +66,47 @@ public class Device
       for(int randomizer = 0; randomizer < DEFAULT_SIZE; randomizer++)
          this.bitLockArray[randomizer] = Math.random()<0.5? true : false;
    }//End Constructor #3
-   
-   
-   
+
+
+
    /**
     * Peek at bits of device.
-    * 
-    * @param pattern indicates which bits to reveal as '?'. pattern.length() 
+    *
+    * @param pattern indicates which bits to reveal as '?'. pattern.length()
     *        must be exactly equal to the number of bits stored in the device.
     * @return a pattern that discloses the values of the indicated btis as 'T' or 'F'
     */
+   @Override
    public CharSequence peek(CharSequence pattern)
    {
-      
+
       return pattern;//TODO
    }//End peek()
-   
-   
-   
+
+
+
    /**
     * Poke bits into device.
-    * 
-    * @param pattern indicator of values of bits to poke. pattern.length() 
-    *        must be exactly equal to the number of bits stored in the device. 
-    *        Values of 'T' or 'F' that correspond to '?' in the preceding peek 
+    *
+    * @param pattern indicator of values of bits to poke. pattern.length()
+    *        must be exactly equal to the number of bits stored in the device.
+    *        Values of 'T' or 'F' that correspond to '?' in the preceding peek
     *        request pattern replace the values in the device.
     */
+   @Override
    public void poke(CharSequence pattern)
    {
       //TODO
    }//End poke()
-   
-   
-   
+
+
+
    /**
     * Initiate device rotation.
-    * 
+    *
     * @return true if all bits have identical value; false otherwise
     */
+   @Override
    public boolean spin()
    {
       boolean startIx = this.bitLockArray[0];
@@ -114,20 +117,20 @@ public class Device
          if(checker == this.bitLockArray.length-1)
             return true;
       }
-      
-      this.rotateOffset = Math.round( 
-       (float)(Math.random() * (100.0+this.rotateOffset) * (double)this.numToPeek) 
+
+      this.rotateOffset = Math.round(
+       (float)(Math.random() * (100.0+this.rotateOffset) * (double)this.numToPeek)
                                     ) % this.bitLockArray.length;
-      
+
       //System.out.println("DEBUG: Rotate offset = " + rotateOffset);
       return false;
    }//End spin()
-   
-   
-   
+
+
+
    /**
     * Render device information as a string.
-    * 
+    *
     * {@inheritDoc}
     * @return rendering that reveals partial state
     */
@@ -143,8 +146,8 @@ public class Device
             this.toReturn += VALUE_FALSE;
       }
       this.toReturn += "]";
-      
+
       return this.toReturn;
    }//End toString()
-   
+
 }//End Device

--- a/src/test/java/FourBitTwoTest.java
+++ b/src/test/java/FourBitTwoTest.java
@@ -5,13 +5,29 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.containsString;
 
-
-
 public class FourBitTwoTest {
+
+  static final boolean USEDEVDEVICE = false;
+
+  static Device buildDevice(boolean[] init, int bits) {
+    if (USEDEVDEVICE) {
+      return new DevDevice(init, bits);
+    } else {
+      return new Device(init, bits);
+    }
+  }
+
+  static Device buildDevice() {
+    if (USEDEVDEVICE) {
+      return new DevDevice();
+    } else {
+      return new Device();
+    }
+  }
 
   @Test public void testItUnlocksTheDeviceWithAllTrue() {
     boolean[] init = {true, true, true, true};
-    Device d = new Device(init, 2);
+    Device d = FourBitTwoTest.buildDevice(init, 2);
     assertTrue(FourBitTwoDisclosureDeviceUnlocker.unlock(d));
     String trace = FourBitTwoDisclosureDeviceUnlocker.showTrace();
     assertThat(trace, containsString("SUCCESS"));
@@ -20,7 +36,7 @@ public class FourBitTwoTest {
 
   @Test public void testItUnlocksTheDeviceWithAllFalse() {
     boolean[] init = {false, false, false, false};
-    Device d = new Device(init, 2);
+    Device d = FourBitTwoTest.buildDevice(init, 2);
     assertTrue(FourBitTwoDisclosureDeviceUnlocker.unlock(d));
     String trace = FourBitTwoDisclosureDeviceUnlocker.showTrace();
     assertThat(trace, containsString("SUCCESS"));
@@ -28,7 +44,7 @@ public class FourBitTwoTest {
   }
 
   @Test public void testItUnlocksTheDeviceWhenSetRandomBits() {
-    Device d = new Device();
+    Device d = FourBitTwoTest.buildDevice();
     assertTrue(FourBitTwoDisclosureDeviceUnlocker.unlock(d));
     String trace = FourBitTwoDisclosureDeviceUnlocker.showTrace();
     assertThat(trace, containsString("SUCCESS"));

--- a/src/test/java/UnfairTestDevice.java
+++ b/src/test/java/UnfairTestDevice.java
@@ -2,9 +2,11 @@
  * Make spin return false always
  */
 class UnfairTestDevice extends Device {
+  @Override
   public boolean spin() {
    return false;
   }
+  @Override
   public CharSequence peek(CharSequence c) {
     return "FF--";
   }


### PR DESCRIPTION
Make Device and DevDevice coexist

Now we we can do different things with DevDevice, yet still fulfill the contract of DeviceUnlocker. This is just one way I could force through the compiler and also get tests to pass with the "real" device and continue to fail with the dev device. 

If anyone has other, better ways of making this happen, let me know.