### PR TITLE
javadoc changes to address #24

### DIFF
--- a/src/main/java/FourBitTwoDisclosureDeviceUnlocker.java
+++ b/src/main/java/FourBitTwoDisclosureDeviceUnlocker.java
@@ -25,7 +25,7 @@ public class FourBitTwoDisclosureDeviceUnlocker extends DeviceUnlocker {
     /**
      *Unlocks a resource controlled by a 4-bit/2-disclosure device. Behavior is unspecified if parameter is not a reference to a valid 4-bit/2-disclosure device.
      *
-     * @param  dev - the device controlling the resource to unlock; must be a 4-bit device with 2 peek/poke bits.
+     * @param  dev the device controlling the resource to unlock; must be a 4-bit device with 2 peek/poke bits.
      * @return  true if the resource is successfully unlocked (all bits are now identical); false otherwise
      */
     public static boolean unlock(Device dev){

--- a/src/main/java/FourBitTwoDisclosureDeviceUnlocker.java
+++ b/src/main/java/FourBitTwoDisclosureDeviceUnlocker.java
@@ -2,12 +2,26 @@
 /**
  * Solution development for 4-bit/2-disclosure device.
  *
- * @version 4.1.5
- * @author Dr. Jody Paul
- * @author Heather DeMarco
+ * @version API: 4.1.4
+ * <br>
+ * Source code: 4.1.7
+ * @author Dr. Jody Paul: API specification, 
+ * <br>
+ *  Heather DeMarco, Jonathan Grant: Source code matching API
+ *  
+ * @see <a href = "http://jodypaul.com/cs/sweprin/deviceProj/projectDescription.html"> Project Description </a>
+ * 
  */
 
 public class FourBitTwoDisclosureDeviceUnlocker extends DeviceUnlocker {
+	
+	/*
+	 * Suppress Instantiation of objects from this utility class
+	 */
+	private FourBitTwoDisclosureDeviceUnlocker() {
+		
+	}
+	
     /**
      *Unlocks a resource controlled by a 4-bit/2-disclosure device. Behavior is unspecified if parameter is not a reference to a valid 4-bit/2-disclosure device.
      *


### PR DESCRIPTION
#24 Ensure that Javadoc matches spec
Associated changes:

1. class description: 

- added @see with link to project description
- (personal preference) provided additional text providing clarification of authorship roles. Probably overkill, but noting who did what is I think valid acknowledgement, and Dr. Paul has not marked me off for doing so in this style for past projects.

2. Constructor Summary: removed by creating private constructor which does nothing.